### PR TITLE
Add support for Apple Silicon

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -43,6 +43,7 @@ install_ghq() {
 
   case "$(uname -m)" in
     x86_64) architecture="amd64" ;;
+    arm64) architecture="amd64" ;;
     *) fail "Unsupported architecture" ;;
   esac
 


### PR DESCRIPTION
Since `ghq` doesn't provide `arm64` binaries for darwin, we use the `amd64` version as a fallback on `arm64` platforms. This allows this plugin to work on M1 laptops. In the future, if `ghq` starts providing a darwin/arm64 binary, we should switch over to that.