### PR TITLE
Add support for ARM64 Linux environment

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -43,7 +43,7 @@ install_ghq() {
 
   case "$(uname -m)" in
     x86_64) architecture="amd64" ;;
-    arm64) architecture="arm64" ;;
+    aarch64 | arm64) architecture="arm64" ;;
     *) fail "Unsupported architecture" ;;
   esac
 


### PR DESCRIPTION
macOS computers on Apple silicon SoC print `arm64` for `uname -m`, but Linux environments on ARM64 print `aarch64`.
This causes installation failure when using Linux VMs on ARM64, such as [multipass](https://multipass.run/) on Apple silicon macOS.

ghq v1.3.0 provides every 3 OS on ARM64 archtecture: https://github.com/x-motemen/ghq/releases/tag/v1.3.0

This installation process can verify inside ARM64 Ubuntu container.

```sh
docker run -it --entrypoint=bash arm64v8/ubuntu
```

```sh
uname -m # => aarch64
apt-get update && \
apt-get upgrade -y && \
apt-get install -y \
  curl \
  git \
  unzip
git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.0
. $HOME/.asdf/asdf.sh

asdf plugin add ghq https://github.com/kajisha/asdf-ghq
asdf install ghq 1.3.0 # => Fail: Unsupported architecture
asdf plugin remove ghq

asdf plugin add ghq https://github.com/t-mario-y/asdf-ghq
cd /root/.asdf/plugins/ghq
git switch support-aarch64
cd -
asdf install ghq 1.3.0 # => The installation was successful!

# and goes on.
touch /root/.tool-versions
asdf global ghq 1.3.0
ghq get kajisha/asdf-ghq
```